### PR TITLE
Wildcard Messages Feature for Chat Waves

### DIFF
--- a/src/main/java/me/serbob/toastedchatwave/Managers/WaveManager.java
+++ b/src/main/java/me/serbob/toastedchatwave/Managers/WaveManager.java
@@ -7,33 +7,40 @@ import me.serbob.toastedchatwave.Util.TierUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.regex.Pattern;
 
 import static me.serbob.toastedchatwave.APIs.PlaceholderAPI.isPAPIenabled;
 
 public class WaveManager {
-    public static boolean isActive=false;
+    public static boolean isActive = false;
     public static List<Player> playersReceived = new ArrayList<>();
     public static String currentWave;
+
     public static boolean receiveRewards(Player player) {
-        if(playersReceived.contains(player)) {
-            return false;
-        }
-        return true;
+        return !playersReceived.contains(player);
     }
-    public static boolean isAvailable(Player player,String message) {
-        if(!isActive) {
+
+    public static boolean isAvailable(Player player, String message) {
+        if (!isActive) {
             return false;
         }
-        if(!ChatColor.stripColor(message).equalsIgnoreCase(ToastedChatWave.instance.getConfig().getString("waves."+currentWave+".word"))) {
-            return false;
+        String waveWord = ToastedChatWave.instance.getConfig().getString("waves." + currentWave + ".word");
+        boolean isWildcard = ToastedChatWave.instance.getConfig().getBoolean("waves." + currentWave + ".wildcard", false);
+
+        if (isWildcard) {
+            return containsWordIgnoreCase(message, waveWord);
+        } else {
+            return ChatColor.stripColor(message).equalsIgnoreCase(waveWord);
         }
-        return true;
+    }
+
+    private static boolean containsWordIgnoreCase(String message, String word) {
+        return Pattern.compile(Pattern.quote(word), Pattern.CASE_INSENSITIVE).matcher(message).find();
     }
     public static void sendRewardMessages(Player player) {
         Bukkit.getScheduler().runTaskLater(ToastedChatWave.instance, () -> {

--- a/src/main/java/me/serbob/toastedchatwave/Managers/WaveManager.java
+++ b/src/main/java/me/serbob/toastedchatwave/Managers/WaveManager.java
@@ -7,6 +7,7 @@ import me.serbob.toastedchatwave.Util.TierUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -17,16 +18,17 @@ import java.util.regex.Pattern;
 import static me.serbob.toastedchatwave.APIs.PlaceholderAPI.isPAPIenabled;
 
 public class WaveManager {
-    public static boolean isActive = false;
+    public static boolean isActive=false;
     public static List<Player> playersReceived = new ArrayList<>();
     public static String currentWave;
-
     public static boolean receiveRewards(Player player) {
-        return !playersReceived.contains(player);
+        if(playersReceived.contains(player)) {
+            return false;
+        }
+        return true;
     }
-
-    public static boolean isAvailable(Player player, String message) {
-        if (!isActive) {
+    public static boolean isAvailable(Player player,String message) {
+        if(!isActive) {
             return false;
         }
         String waveWord = ToastedChatWave.instance.getConfig().getString("waves." + currentWave + ".word");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,7 @@ show_in_chat_method: "message_reformat" # you can also put instead of 'message_r
 waves:
   gg_wave:
     word: "GG"
+    wildcard: true
     wave-started:
       - "&cWave started"
       - "Type gg for &c500$"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@ show_in_chat_method: "message_reformat" # you can also put instead of 'message_r
 waves:
   gg_wave:
     word: "GG"
-    wildcard: true
+    wildcard: false
     wave-started:
       - "&cWave started"
       - "Type gg for &c500$"


### PR DESCRIPTION
Added a wildcard ability, it'll only be enabled for a specific wave if the wildcard is set to true in the config. If there is no `wildcard` in a wave it'll work as normal.
```
  welcome_wave:
    word: Welcome
    wildcard: true 
```

![image](https://github.com/SerbanHiro/ToastedChatWave/assets/63890666/864bd041-721f-4815-beb7-473fb9bd5978)